### PR TITLE
csv reporter: fix order-of-magnitude formatting

### DIFF
--- a/temci/report/report.py
+++ b/temci/report/report.py
@@ -2202,7 +2202,7 @@ class CSVReporter(AbstractReporter):
         }
         num = mod[modifier]()
         return FNumber(num,
-                       abs_deviation=(single.std_dev() if "p" in opts else None),
+                       abs_deviation=single.std_dev(),
                        is_percent=("%" in opts),
                        scientific_notation=("s" in opts),
                        parentheses=("o" in opts or "p" in opts),


### PR DESCRIPTION
always computing the stddev probably doesn't hurt too much here, all things considered...?