### PR TITLE
nix: fix `perf` dependency

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -24,7 +24,7 @@ in buildPythonApplication rec {
     tablib unicodecsv
     scipy seaborn
     pyyaml
-  ] ++ pkgs.lib.optional pkgs.stdenv.isLinux perf;
+  ] ++ pkgs.lib.optional pkgs.stdenv.isLinux pkgs.linuxPackages.perf;
   postInstall = ''
     $out/bin/temci setup
   '';


### PR DESCRIPTION
The previous reference was to the Python package, which recently
was renamed to `pyperf`. Whoops.

So maybe the base Nix packages are still sufficiently stable
that we don't necessarily need to pin them after all (which
we would forget to update anyway).