### PR TITLE
Fix bug where `temci` would crash while trying to configure cpusets

### DIFF
--- a/temci/run/cpuset.py
+++ b/temci/run/cpuset.py
@@ -316,7 +316,7 @@ class CPUSet:
         :raises EnvironmentError: if something goes wrong
         """
         # cmd = ["/bin/sh", "-c", "sudo cset {}".format(argument)]
-        cmd = ["/bin/sh", "-c", "python3 -ct 'import cpuset.main; print(cpuset.main.main())' " + argument]
+        cmd = ["/bin/sh", "-c", "python3 -c 'import cpuset.main; print(cpuset.main.main())' " + argument]
         proc = subprocess.Popen(cmd,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE,


### PR DESCRIPTION
I was running into the same issue as the user from #126 in [their last comment on the issue](https://github.com/parttimenerd/temci/issues/126#issuecomment-876907633). I was able to identify the source of this error, and fixed it so that `temci` no longer crashes while trying to configure cpusets. This closes #126.