### PR TITLE
Make temp command file readable to user used for benching

### DIFF
--- a/temci/run/run_driver.py
+++ b/temci/run/run_driver.py
@@ -754,6 +754,7 @@ class ExecRunDriver(AbstractRunDriver):
             cmd_tmp_file.flush()
             cmd_tmp_file.close()
             if bench_as_different_user():
+                shutil.chown(cmd_tmp_file.name, get_bench_user())
                 cmd = pre + " sudo -u {} -E  PATH={} sh {}".format(get_bench_user(),
                                                                shlex.quote(Settings()["env"]["PATH"]),
                                                                cmd_tmp_file.name) + post


### PR DESCRIPTION
I ran into the same issue as described here: https://github.com/parttimenerd/temci/issues/126#issuecomment-874899069

I think the cause is that when benchmarking under a different user (so, with `sudo`), the "others" permissions are checked upon accessing the temporary command file.
Also, since it is not executed directly, but read by a shell interpreter instead, the `read` permission has to be set. Some shells may also require the `execute` bit to actually run the script, but mine didn't, so I didn't add it here.

At least this change solved the above error for me.