### PR TITLE
Add runner plugin to disable AMD Turbo Boost

### DIFF
--- a/temci/run/run_driver.py
+++ b/temci/run/run_driver.py
@@ -568,12 +568,13 @@ class ValidRusagePropertyList(ValidPropertyList):
 
 
 _INTEL = ",disable_intel_turbo" if does_command_succeed("ls /sys/devices/system/cpu/intel_pstate/no_turbo") else ""
+_AMD = ",disable_amd_boost" if does_command_succeed("ls /sys/devices/system/cpu/cpufreq/boost") else ""
 
 PRESET_PLUGIN_MODES = {
     "none": ("", "enable none by default"),
-    "all": ("cpu_governor,disable_swap,sync,stop_start,other_nice,nice,disable_aslr,disable_ht,cpuset" + _INTEL,
+    "all": ("cpu_governor,disable_swap,sync,stop_start,other_nice,nice,disable_aslr,disable_ht,cpuset" + _INTEL + _AMD,
             "enable all, might freeze your system"),
-    "usable": ("cpu_governor,disable_swap,sync,nice,disable_aslr,disable_ht,cpuset" + _INTEL,
+    "usable": ("cpu_governor,disable_swap,sync,nice,disable_aslr,disable_ht,cpuset" + _INTEL + _AMD,
                "like 'all' but doesn't affect other processes")
 }
 

--- a/temci/run/run_driver_plugin.py
+++ b/temci/run/run_driver_plugin.py
@@ -500,6 +500,21 @@ class DisableIntelTurbo(AbstractRunDriverPlugin):
         self._exec_command("echo 0 > /sys/devices/system/cpu/intel_pstate/no_turbo")
 
 
+@register(ExecRunDriver, "disable_amd_boost", Dict({}))
+class DisableIntelTurbo(AbstractRunDriverPlugin):
+    """
+    Disable amd turbo boost
+    """
+
+    needs_root_privileges = True
+
+    def setup(self):
+        self._exec_command("echo 0 > /sys/devices/system/cpu/cpufreq/boost")
+
+    def teardown(self):
+        self._exec_command("echo 1 > /sys/devices/system/cpu/cpufreq/boost")
+
+
 @register(ExecRunDriver, "cpuset", Dict({}))
 class CPUSet(AbstractRunDriverPlugin):
     """


### PR DESCRIPTION
This can be done very similarly to the Intel variant, according to:
https://easyperf.net/blog/2019/08/02/Perf-measurement-environment-on-Linux#1-disable-turboboost

Wouldn't it be neater though, if these plugins read and stored the state set upon `setup`, and restored that in `teardown`?
This way it will enable boost after a benchmark, even if it wasn't enabled before.